### PR TITLE
Modify the build's handling of the Windows HID libraries.

### DIFF
--- a/CMake/CleanDirectoryList.cmake
+++ b/CMake/CleanDirectoryList.cmake
@@ -1,0 +1,48 @@
+# - Removes duplicate entries and non-directories from a provided list
+#
+#  clean_directory_list(<listvar> [<additional list items>...])
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+if(__clean_directory_list)
+	return()
+endif()
+set(__clean_directory_list YES)
+
+function(clean_directory_list _var)
+	# combine variable's current value with additional list items
+	set(_in ${${_var}} ${ARGN})
+
+	if(_in)
+		# Initial list cleaning
+		list(REMOVE_DUPLICATES _in)
+
+		# Grab the absolute path of each actual directory
+		set(_out)
+		foreach(_dir ${_in})
+			if(IS_DIRECTORY "${_dir}")
+				get_filename_component(_dir "${_dir}" ABSOLUTE)
+				file(TO_CMAKE_PATH "${_dir}" _dir)
+				list(APPEND _out "${_dir}")
+			endif()
+		endforeach()
+
+		if(_out)
+			# Clean up the output list now
+			list(REMOVE_DUPLICATES _out)
+		endif()
+
+		# return _out
+		set(${_var} "${_out}" PARENT_SCOPE)
+	endif()
+endfunction()

--- a/CMake/FindWinHID.cmake
+++ b/CMake/FindWinHID.cmake
@@ -1,0 +1,288 @@
+# - try to find Windows HID support, part of the WDK/DDK
+#
+# Cache Variables: (probably not for direct use in your scripts)
+#  WINHID_INCLUDE_DIR
+#  WINHID_CRT_INCLUDE_DIR
+#  WINHID_LIBRARY
+#
+# Non-cache variables you might use in your CMakeLists.txt:
+#  WINHID_FOUND
+#  WINHID_INCLUDE_DIRS
+#  WINHID_LIBRARIES
+#
+# Requires these CMake modules:
+#  FindPackageHandleStandardArgs (known included with CMake >=2.6.2)
+#  PrefixListGlob
+#  CleanDirectoryList
+#  MinGWSearchPathExtras
+#  FindWindowsSDK
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+if(NOT WIN32)
+	find_package_handle_standard_args(WinHID
+		"Skipping search for Windows HID on non-Windows platform"
+		WIN32)
+	return()
+endif()
+
+if(MSVC)
+	if( (NOT WINHID_ROOT_DIR) AND (NOT ENV{DDKROOT} STREQUAL "") )
+		set(WINHID_ROOT_DIR "$ENV{DDKROOT}")
+	endif()
+endif()
+
+set(WINHID_ROOT_DIR
+	"${WINHID_ROOT_DIR}"
+	CACHE
+	PATH
+	"Directory to search")
+
+set(_deps_check)
+set(_need_crt_dir)
+if(MSVC)
+
+	find_package(WindowsSDK)
+	set(WINSDK_LIBDIRS)
+	if(WINDOWSSDK_FOUND)
+		get_windowssdk_library_dirs_multiple(WINSDK_LIBDIRS ${WINDOWSSDK_PREFERRED_FIRST_DIRS})
+		foreach(WINSDKDIR ${WINDOWSSDK_DIRS})
+			get_windowssdk_library_dirs(${WINSDKDIR} WINSDK_CURRENT_LIBDIRS)
+			list(APPEND WINSDK_LIBDIRS ${WINSDK_CURRENT_LIBDIRS})
+		endforeach()
+	endif()
+
+	if(CMAKE_SIZEOF_VOID_P MATCHES "8")
+		set(_arch amd64) # what the architecture used to be called
+		set(_arch8 x64) # what the WDK for Win8+ calls this architecture
+	else()
+		set(_arch i386) # what the architecture used to be called
+		set(_arch8 x86) # what the WDK for Win8+ calls this architecture
+	endif()
+	include(PrefixListGlob)
+	include(CleanDirectoryList)
+	prefix_list_glob(_prefixed
+		"*/"
+		"$ENV{SYSTEMDRIVE}/WinDDK/"
+		"$ENV{ProgramFiles}/Windows Kits/"
+		"c:/WinDDK/")
+	clean_directory_list(_prefixed)
+	find_library(WINHID_LIBRARY
+		NAMES
+		hid
+		libhid
+		PATHS
+		"${WINHID_ROOT_DIR}"
+		${WINSDK_LIBDIRS}
+		${_prefixed}
+		PATH_SUFFIXES
+		"lib/w2k/${_arch}" # Win2k min requirement
+		"lib/wxp/${_arch}" # WinXP min requirement
+		"lib/wnet/${_arch}" # Win Server 2003 min requirement
+		"lib/wlh/${_arch}" # Win Vista ("Long Horn") min requirement
+		"lib/wlh/um/${_arch8}" # Win Vista ("Long Horn") min requirement
+		"lib/win7/${_arch}" # Win 7 min requirement
+		"lib/win7/um/${_arch8}" # Win 7 min requirement
+		"lib/win8/${_arch}" # Win 8 min requirement
+		"lib/win8/um/${_arch8}" # Win 8 min requirement
+		)
+	# Might want to look close to the library first for the includes.
+	if(WINHID_LIBRARY)
+		get_filename_component(WINHID_LIBRARY_DIR "${WINHID_LIBRARY}" PATH)
+		if(WINDOWSSDK_FOUND)
+			get_windowssdk_from_component("${WINHID_LIBRARY}" _USED_WINSDK)
+			set(WINHID_LIBRARY_FROM_WINDOWSSDK ON)
+			get_windowssdk_include_dirs(${_USED_WINSDK} WINHID_INCLUDE_HINTS)
+		endif()
+	endif()
+
+	find_library(WINHID_SETUPAPI_LIBRARY
+		NAMES
+		setupapi
+		HINTS
+		"${WINHID_LIBRARY_DIR}"
+		PATHS
+		"${WINHID_ROOT_DIR}"
+		${WINSDK_LIBDIRS}
+		${_prefixed}
+		PATH_SUFFIXES
+		"lib/w2k/${_arch}" # Win2k min requirement
+		"lib/wxp/${_arch}" # WinXP min requirement
+		"lib/wnet/${_arch}" # Win Server 2003 min requirement
+		"lib/wlh/${_arch}" # Win Vista ("Long Horn") min requirement
+		"lib/wlh/um/${_arch8}" # Win Vista ("Long Horn") min requirement
+		"lib/win7/${_arch}" # Win 7 min requirement
+		"lib/win7/um/${_arch8}" # Win 7 min requirement
+		"lib/win8/${_arch}" # Win 8 min requirement
+		"lib/win8/um/${_arch8}" # Win 8 min requirement
+		)
+
+	if(WINHID_LIBRARY AND NOT WINHID_LIBRARY_FROM_WINDOWSSDK)
+		set(_basedir "${WINHID_LIBRARY_DIR}")
+		set(_prevdir)
+		while(NOT IS_DIRECTORY "${_basedir}/lib" AND NOT (_basedir STREQUAL _prevdir))
+			set(_prevdir "${_basedir}")
+			get_filename_component(_basedir "${_basedir}/.." ABSOLUTE)
+		endwhile()
+
+		set(WINHID_INCLUDE_HINTS "${_basedir}")
+
+		if(EXISTS "${_basedir}/inc")
+			find_path(WINHID_CRT_INCLUDE_DIR # otherwise you get weird compile errors
+				NAMES
+				stdio.h
+				HINTS
+				"${_basedir}"
+				PATHS
+				"${WINHID_ROOT_DIR}"
+				PATH_SUFFIXES
+				inc/crt
+				NO_DEFAULT_PATH)
+			list(APPEND _deps_check WINHID_CRT_INCLUDE_DIR)
+			set(_need_crt_dir ON)
+		endif()
+	endif()
+	find_path(WINHID_INCLUDE_DIR
+		NAMES
+		hidsdi.h
+		HINTS
+		${WINHID_INCLUDE_HINTS}
+		PATHS
+		"${WINHID_ROOT_DIR}"
+		PATH_SUFFIXES
+		inc/ddk
+		inc/api
+		inc/w2k
+		inc/wxp
+		inc/wnet
+		include/shared)
+else()
+	# This is the non-MSVC path.
+	if(MINGW)
+		include(MinGWSearchPathExtras)
+
+		find_library(WINHID_LIBRARY
+			NAMES
+			libhid
+			HINTS
+			"${WINHID_ROOT_DIR}"
+			${MINGWSEARCH_LIBRARY_DIRS}
+			/mingw
+			PATH_SUFFIXES
+			lib
+			lib/w32api)
+		find_library(WINHID_SETUPAPI_LIBRARY
+			NAMES
+			libsetupapi
+			HINTS
+			"${WINHID_ROOT_DIR}"
+			${MINGWSEARCH_LIBRARY_DIRS}
+			/mingw
+			PATH_SUFFIXES
+			lib
+			lib/w32api)
+	else()
+		find_library(WINHID_LIBRARY
+			NAMES
+			hid
+			libhid
+			HINTS
+			"${WINHID_ROOT_DIR}"
+			/mingw
+			PATH_SUFFIXES
+			lib
+			lib/w32api)
+		find_library(WINHID_SETUPAPI_LIBRARY
+			NAMES
+			setupapi
+			libsetupapi
+			HINTS
+			"${WINHID_ROOT_DIR}"
+			/mingw
+			PATH_SUFFIXES
+			lib
+			lib/w32api)
+	endif()
+	find_path(WINHID_INCLUDE_DIR
+		NAMES
+		hidsdi.h
+		PATHS
+		"${WINHID_ROOT_DIR}"
+		${MINGWSEARCH_INCLUDE_DIRS}
+		/mingw
+		PATH_SUFFIXES
+		include/w32api/ddk
+		include/ddk
+		ddk)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(WinHID
+	DEFAULT_MSG
+	WINHID_LIBRARY
+	WINHID_SETUPAPI_LIBRARY
+	WINHID_INCLUDE_DIR
+	${_deps_check})
+
+if(WINHID_FOUND)
+	if(MSVC)
+		set(_winreq)
+		if(WINHID_LIBRARY MATCHES "[Ll]ib/w2k")
+			set(_winreq "Windows 2000")
+		elseif(WINHID_LIBRARY MATCHES "[Ll]ib/wxp")
+			set(_winreq "Windows XP")
+		elseif(WINHID_LIBRARY MATCHES "[Ll]ib/wnet")
+			set(_winreq "Windows Server 2003")
+		elseif(WINHID_LIBRARY MATCHES "[Ll]ib/wlh")
+			set(_winreq "Windows Vista")
+		elseif(WINHID_LIBRARY MATCHES "[Ll]ib/win7")
+			set(_winreq "Windows 7")
+		elseif(WINHID_LIBRARY MATCHES "[Ll]ib/win8")
+			set(_winreq "Windows 8")
+			set(_winreq_uncertain ON)
+		elseif(WINHID_LIBRARY MATCHES "[Ll]ib/winv6.3")
+			set(_winreq "Windows 8.1")
+			set(_winreq_uncertain ON)
+		elseif(WINHID_LIBRARY MATCHES "[Ll]ib/10.0")
+			set(_winreq "Windows 10")
+			set(_winreq_uncertain ON)
+		endif()
+		if(NOT "${WINHID_MIN_WINDOWS_VER}" STREQUAL "${_winreq}")
+			if(NOT WinHID_FIND_QUIETLY)
+				if(NOT _winreq)
+					message("Couldn't determine if the WINHID_LIBRARY would result in a minimum version compatibility requirement.")
+				elseif(_winreq_uncertain)
+					message(STATUS
+					"Found WINHID_LIBRARY in the Windows SDK for ${_winreq} , which may or may not affect minimum compatible Windows version.")
+				else()
+					message(STATUS
+						"Linking against WINHID_LIBRARY will enforce this minimum version: ${_winreq}")
+				endif()
+			endif()
+			set(WINHID_MIN_WINDOWS_VER "${_winreq}" CACHE INTERNAL "" FORCE)
+		endif()
+	endif()
+	set(WINHID_LIBRARIES "${WINHID_LIBRARY}" "${WINHID_SETUPAPI_LIBRARY}")
+	if(_need_crt_dir)
+		set(WINHID_INCLUDE_DIRS
+			"${WINHID_CRT_INCLUDE_DIR}"
+			"${WINHID_INCLUDE_DIR}")
+	else()
+		# Don't need that CRT include dir for WDK 8+
+		set(WINHID_INCLUDE_DIRS
+			"${WINHID_INCLUDE_DIR}")
+	endif()
+	mark_as_advanced(WINHID_ROOT_DIR)
+endif()
+
+mark_as_advanced(WINHID_INCLUDE_DIR
+	WINHID_CRT_INCLUDE_DIR
+	WINHID_LIBRARY)

--- a/CMake/FindWindowsSDK.cmake
+++ b/CMake/FindWindowsSDK.cmake
@@ -1,0 +1,625 @@
+# - Find the Windows SDK aka Platform SDK
+#
+# Relevant Wikipedia article: http://en.wikipedia.org/wiki/Microsoft_Windows_SDK
+#
+# Pass "COMPONENTS tools" to ignore Visual Studio version checks: in case
+# you just want the tool binaries to run, rather than the libraries and headers
+# for compiling.
+#
+# Variables:
+#  WINDOWSSDK_FOUND - if any version of the windows or platform SDK was found that is usable with the current version of visual studio
+#  WINDOWSSDK_LATEST_DIR
+#  WINDOWSSDK_LATEST_NAME
+#  WINDOWSSDK_FOUND_PREFERENCE - if we found an entry indicating a "preferred" SDK listed for this visual studio version
+#  WINDOWSSDK_PREFERRED_DIR
+#  WINDOWSSDK_PREFERRED_NAME
+#
+#  WINDOWSSDK_DIRS - contains no duplicates, ordered most recent first.
+#  WINDOWSSDK_PREFERRED_FIRST_DIRS - contains no duplicates, ordered with preferred first, followed by the rest in descending recency
+#
+# Functions:
+#  windowssdk_name_lookup(<directory> <output variable>) - Find the name corresponding with the SDK directory you pass in, or
+#     NOTFOUND if not recognized. Your directory must be one of WINDOWSSDK_DIRS for this to work.
+#
+#  windowssdk_build_lookup(<directory> <output variable>) - Find the build version number corresponding with the SDK directory you pass in, or
+#     NOTFOUND if not recognized. Your directory must be one of WINDOWSSDK_DIRS for this to work.
+#
+#  get_windowssdk_from_component(<file or dir> <output variable>) - Given a library or include dir,
+#     find the Windows SDK root dir corresponding to it, or NOTFOUND if unrecognized.
+#
+#  get_windowssdk_library_dirs(<directory> <output variable>) - Find the architecture-appropriate
+#     library directories corresponding to the SDK directory you pass in (or NOTFOUND if none)
+#
+#  get_windowssdk_library_dirs_multiple(<output variable> <directory> ...) - Find the architecture-appropriate
+#     library directories corresponding to the SDK directories you pass in, in order, skipping those not found. NOTFOUND if none at all.
+#     Good for passing WINDOWSSDK_DIRS or WINDOWSSDK_DIRS to if you really just want a file and don't care where from.
+#
+#  get_windowssdk_include_dirs(<directory> <output variable>) - Find the
+#     include directories corresponding to the SDK directory you pass in (or NOTFOUND if none)
+#
+#  get_windowssdk_include_dirs_multiple(<output variable> <directory> ...) - Find the
+#     include directories corresponding to the SDK directories you pass in, in order, skipping those not found. NOTFOUND if none at all.
+#     Good for passing WINDOWSSDK_DIRS or WINDOWSSDK_DIRS to if you really just want a file and don't care where from.
+#
+# Requires these CMake modules:
+#  FindPackageHandleStandardArgs (known included with CMake >=2.6.2)
+#
+# Original Author:
+# 2012 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2012.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+set(_preferred_sdk_dirs) # pre-output
+set(_win_sdk_dirs) # pre-output
+set(_win_sdk_versanddirs) # pre-output
+set(_win_sdk_buildsanddirs) # pre-output
+set(_winsdk_vistaonly) # search parameters
+set(_winsdk_kits) # search parameters
+
+
+set(_WINDOWSSDK_ANNOUNCE OFF)
+if(NOT WINDOWSSDK_FOUND AND (NOT WindowsSDK_FIND_QUIETLY))
+	set(_WINDOWSSDK_ANNOUNCE ON)
+endif()
+macro(_winsdk_announce)
+	if(_WINSDK_ANNOUNCE)
+		message(STATUS ${ARGN})
+	endif()
+endmacro()
+
+set(_winsdk_win10vers
+	10.0.10586.0 # TH2 aka Win10 1511
+	10.0.10240.0 # Win10 RTM
+	10.0.10150.0 # just ucrt
+	10.0.10056.0
+)
+
+if(WindowsSDK_FIND_COMPONENTS MATCHES "tools")
+	set(_WINDOWSSDK_IGNOREMSVC ON)
+	_winsdk_announce("Checking for tools from Windows/Platform SDKs...")
+else()
+	set(_WINDOWSSDK_IGNOREMSVC OFF)
+	_winsdk_announce("Checking for Windows/Platform SDKs...")
+endif()
+
+# Appends to the three main pre-output lists used only if the path exists
+# and is not already in the list.
+function(_winsdk_conditional_append _vername _build _path)
+	if(("${_path}" MATCHES "registry") OR (NOT EXISTS "${_path}"))
+		# Path invalid - do not add
+		return()
+	endif()
+	list(FIND _win_sdk_dirs "${_path}" _win_sdk_idx)
+	if(_win_sdk_idx GREATER -1)
+		# Path already in list - do not add
+		return()
+	endif()
+	_winsdk_announce( " - ${_vername}, Build ${_build} @ ${_path}")
+	# Not yet in the list, so we'll add it
+	list(APPEND _win_sdk_dirs "${_path}")
+	set(_win_sdk_dirs "${_win_sdk_dirs}" CACHE INTERNAL "" FORCE)
+	list(APPEND
+		_win_sdk_versanddirs
+		"${_vername}"
+		"${_path}")
+	set(_win_sdk_versanddirs "${_win_sdk_versanddirs}" CACHE INTERNAL "" FORCE)
+	list(APPEND
+		_win_sdk_buildsanddirs
+		"${_build}"
+		"${_path}")
+	set(_win_sdk_buildsanddirs "${_win_sdk_buildsanddirs}" CACHE INTERNAL "" FORCE)
+endfunction()
+
+# Appends to the "preferred SDK" lists only if the path exists
+function(_winsdk_conditional_append_preferred _info _path)
+	if(("${_path}" MATCHES "registry") OR (NOT EXISTS "${_path}"))
+		# Path invalid - do not add
+		return()
+	endif()
+
+	get_filename_component(_path "${_path}" ABSOLUTE)
+
+	list(FIND _win_sdk_preferred_sdk_dirs "${_path}" _win_sdk_idx)
+	if(_win_sdk_idx GREATER -1)
+		# Path already in list - do not add
+		return()
+	endif()
+	_winsdk_announce( " - Found \"preferred\" SDK ${_info} @ ${_path}")
+	# Not yet in the list, so we'll add it
+	list(APPEND _win_sdk_preferred_sdk_dirs "${_path}")
+	set(_win_sdk_preferred_sdk_dirs "${_win_sdk_dirs}" CACHE INTERNAL "" FORCE)
+
+	# Just in case we somehow missed it:
+	_winsdk_conditional_append("${_info}" "" "${_path}")
+endfunction()
+
+# Given a version like v7.0A, looks for an SDK in the registry under "Microsoft SDKs".
+# If the given version might be in both HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows
+# and HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots aka "Windows Kits",
+# use this macro first, since these registry keys usually have more information.
+#
+# Pass a "default" build number as an extra argument in case we can't find it.
+function(_winsdk_check_microsoft_sdks_registry _winsdkver)
+	set(SDKKEY "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows\\${_winsdkver}")
+	get_filename_component(_sdkdir
+		"[${SDKKEY};InstallationFolder]"
+		ABSOLUTE)
+
+	set(_sdkname "Windows SDK ${_winsdkver}")
+
+	# Default build number passed as extra argument
+	set(_build ${ARGN})
+	# See if the registry holds a Microsoft-mutilated, err, designated, product name
+	# (just using get_filename_component to execute the registry lookup)
+	get_filename_component(_sdkproductname
+		"[${SDKKEY};ProductName]"
+		NAME)
+	if(NOT "${_sdkproductname}" MATCHES "registry")
+		# Got a product name
+		set(_sdkname "${_sdkname} (${_sdkproductname})")
+	endif()
+
+	# try for a version to augment our name
+	# (just using get_filename_component to execute the registry lookup)
+	get_filename_component(_sdkver
+		"[${SDKKEY};ProductVersion]"
+		NAME)
+	if(NOT "${_sdkver}" MATCHES "registry" AND NOT MATCHES)
+		# Got a version
+		if(NOT "${_sdkver}" MATCHES "\\.\\.")
+			# and it's not an invalid one with two dots in it:
+			# use to override the default build
+			set(_build ${_sdkver})
+			if(NOT "${_sdkname}" MATCHES "${_sdkver}")
+				# Got a version that's not already in the name, let's use it to improve our name.
+				set(_sdkname "${_sdkname} (${_sdkver})")
+			endif()
+		endif()
+	endif()
+	_winsdk_conditional_append("${_sdkname}" "${_build}" "${_sdkdir}")
+endfunction()
+
+# Given a name for identification purposes, the build number, and a key (technically a "value name")
+# corresponding to a Windows SDK packaged as a "Windows Kit", look for it
+# in HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots
+# Note that the key or "value name" tends to be something weird like KitsRoot81 -
+# no easy way to predict, just have to observe them in the wild.
+# Doesn't hurt to also try _winsdk_check_microsoft_sdks_registry for these:
+# sometimes you get keys in both parts of the registry (in the wow64 portion especially),
+# and the non-"Windows Kits" location is often more descriptive.
+function(_winsdk_check_windows_kits_registry _winkit_name _winkit_build _winkit_key)
+	get_filename_component(_sdkdir
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;${_winkit_key}]"
+		ABSOLUTE)
+	_winsdk_conditional_append("${_winkit_name}" "${_winkit_build}" "${_sdkdir}")
+endfunction()
+
+# Given a name for identification purposes and the build number
+# corresponding to a Windows 10 SDK packaged as a "Windows Kit", look for it
+# in HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots
+# Doesn't hurt to also try _winsdk_check_microsoft_sdks_registry for these:
+# sometimes you get keys in both parts of the registry (in the wow64 portion especially),
+# and the non-"Windows Kits" location is often more descriptive.
+function(_winsdk_check_win10_kits _winkit_build)
+	get_filename_component(_sdkdir
+		"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]"
+		ABSOLUTE)
+	if(("${_sdkdir}" MATCHES "registry") OR (NOT EXISTS "${_sdkdir}"))
+		return() # not found
+	endif()
+	if(EXISTS "${_sdkdir}/Include/${_winkit_build}/um")
+		_winsdk_conditional_append("Windows Kits 10 (Build ${_winkit_build})" "${_winkit_build}" "${_sdkdir}")
+	endif()
+endfunction()
+
+# Given a name for indentification purposes, the build number, and the associated package GUID,
+# look in the registry under both HKLM and HKCU in \\SOFTWARE\\Microsoft\\MicrosoftSDK\\InstalledSDKs\\
+# for that guid and the SDK it points to.
+function(_winsdk_check_platformsdk_registry _platformsdkname _build _platformsdkguid)
+	foreach(_winsdk_hive HKEY_LOCAL_MACHINE HKEY_CURRENT_USER)
+		get_filename_component(_sdkdir
+			"[${_winsdk_hive}\\SOFTWARE\\Microsoft\\MicrosoftSDK\\InstalledSDKs\\${_platformsdkguid};Install Dir]"
+			ABSOLUTE)
+		_winsdk_conditional_append("${_platformsdkname} (${_build})" "${_build}" "${_sdkdir}")
+	endforeach()
+endfunction()
+
+###
+# Detect toolchain information: to know whether it's OK to use Vista+ only SDKs
+###
+set(_winsdk_vistaonly_ok OFF)
+if(MSVC AND NOT _WINDOWSSDK_IGNOREMSVC)
+	# VC 10 and older has broad target support
+	if(MSVC_VERSION LESS 1700)
+		# VC 11 by default targets Vista and later only, so we can add a few more SDKs that (might?) only work on vista+
+	elseif("${CMAKE_VS_PLATFORM_TOOLSET}" MATCHES "_xp")
+		# This is the XP-compatible v110+ toolset
+	elseif("${CMAKE_VS_PLATFORM_TOOLSET}" STREQUAL "v100" OR "${CMAKE_VS_PLATFORM_TOOLSET}" STREQUAL "v90")
+		# This is the VS2010/VS2008 toolset
+	else()
+		# OK, we're VC11 or newer and not using a backlevel or XP-compatible toolset.
+		# These versions have no XP (and possibly Vista pre-SP1) support
+		set(_winsdk_vistaonly_ok ON)
+		if(_WINDOWSSDK_ANNOUNCE AND NOT _WINDOWSSDK_VISTAONLY_PESTERED)
+			set(_WINDOWSSDK_VISTAONLY_PESTERED ON CACHE INTERNAL "" FORCE)
+			message(STATUS "FindWindowsSDK: Detected Visual Studio 2012 or newer, not using the _xp toolset variant: including SDK versions that drop XP support in search!")
+		endif()
+	endif()
+endif()
+if(_WINDOWSSDK_IGNOREMSVC)
+	set(_winsdk_vistaonly_ok ON)
+endif()
+
+###
+# MSVC version checks - keeps messy conditionals in one place
+# (messy because of _WINDOWSSDK_IGNOREMSVC)
+###
+set(_winsdk_msvc_greater_1200 OFF)
+if(_WINDOWSSDK_IGNOREMSVC OR (MSVC AND (MSVC_VERSION GREATER 1200)))
+	set(_winsdk_msvc_greater_1200 ON)
+endif()
+# Newer than VS .NET/VS Toolkit 2003
+set(_winsdk_msvc_greater_1310 OFF)
+if(_WINDOWSSDK_IGNOREMSVC OR (MSVC AND (MSVC_VERSION GREATER 1310)))
+	set(_winsdk_msvc_greater_1310 ON)
+endif()
+
+# VS2005/2008
+set(_winsdk_msvc_less_1600 OFF)
+if(_WINDOWSSDK_IGNOREMSVC OR (MSVC AND (MSVC_VERSION LESS 1600)))
+	set(_winsdk_msvc_less_1600 ON)
+endif()
+
+# VS2013+
+set(_winsdk_msvc_not_less_1800 OFF)
+if(_WINDOWSSDK_IGNOREMSVC OR (MSVC AND (NOT MSVC_VERSION LESS 1800)))
+	set(_winsdk_msvc_not_less_1800 ON)
+endif()
+
+###
+# START body of find module
+###
+if(_winsdk_msvc_greater_1310) # Newer than VS .NET/VS Toolkit 2003
+	###
+	# Look for "preferred" SDKs
+	###
+
+	# Environment variable for SDK dir
+	if(EXISTS "$ENV{WindowsSDKDir}" AND (NOT "$ENV{WindowsSDKDir}" STREQUAL ""))
+		_winsdk_conditional_append_preferred("WindowsSDKDir environment variable" "$ENV{WindowsSDKDir}")
+	endif()
+
+	if(_winsdk_msvc_less_1600)
+		# Per-user current Windows SDK for VS2005/2008
+		get_filename_component(_sdkdir
+			"[HKEY_CURRENT_USER\\Software\\Microsoft\\Microsoft SDKs\\Windows;CurrentInstallFolder]"
+			ABSOLUTE)
+		_winsdk_conditional_append_preferred("Per-user current Windows SDK" "${_sdkdir}")
+
+		# System-wide current Windows SDK for VS2005/2008
+		get_filename_component(_sdkdir
+			"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows;CurrentInstallFolder]"
+			ABSOLUTE)
+		_winsdk_conditional_append_preferred("System-wide current Windows SDK" "${_sdkdir}")
+	endif()
+
+	###
+	# Begin the massive list of SDK searching!
+	###
+	if(_winsdk_vistaonly_ok AND _winsdk_msvc_not_less_1800)
+		# These require at least Visual Studio 2013 (VC12)
+
+		_winsdk_check_microsoft_sdks_registry(v10.0A)
+
+		# Windows Software Development Kit (SDK) for Windows 10
+		# Several different versions living in the same directory - if nothing else we can assume RTM (10240)
+		_winsdk_check_microsoft_sdks_registry(v10.0 10.0.10240.0)
+		foreach(_win10build ${_winsdk_win10vers})
+			_winsdk_check_win10_kits(${_win10build})
+		endforeach()
+	endif() # vista-only and 2013+
+
+	# Included in Visual Studio 2013
+	# Includes the v120_xp toolset
+	_winsdk_check_microsoft_sdks_registry(v8.1A 8.1.51636)
+
+	if(_winsdk_vistaonly_ok AND _winsdk_msvc_not_less_1800)
+		# Windows Software Development Kit (SDK) for Windows 8.1
+		# http://msdn.microsoft.com/en-gb/windows/desktop/bg162891
+		_winsdk_check_microsoft_sdks_registry(v8.1 8.1.25984.0)
+		_winsdk_check_windows_kits_registry("Windows Kits 8.1" 8.1.25984.0 KitsRoot81)
+	endif() # vista-only and 2013+
+
+	if(_winsdk_vistaonly_ok)
+		# Included in Visual Studio 2012
+		_winsdk_check_microsoft_sdks_registry(v8.0A 8.0.50727)
+
+		# Microsoft Windows SDK for Windows 8 and .NET Framework 4.5
+		# This is the first version to also include the DirectX SDK
+		# http://msdn.microsoft.com/en-US/windows/desktop/hh852363.aspx
+		_winsdk_check_microsoft_sdks_registry(v8.0 6.2.9200.16384)
+		_winsdk_check_windows_kits_registry("Windows Kits 8.0" 6.2.9200.16384 KitsRoot)
+	endif() # vista-only
+
+	# Included with VS 2012 Update 1 or later
+	# Introduces v110_xp toolset
+	_winsdk_check_microsoft_sdks_registry(v7.1A 7.1.51106)
+	if(_winsdk_vistaonly_ok)
+		# Microsoft Windows SDK for Windows 7 and .NET Framework 4
+		# http://www.microsoft.com/downloads/en/details.aspx?FamilyID=6b6c21d2-2006-4afa-9702-529fa782d63b
+		_winsdk_check_microsoft_sdks_registry(v7.1 7.1.7600.0.30514)
+	endif() # vista-only
+
+	# Included with VS 2010
+	_winsdk_check_microsoft_sdks_registry(v7.0A 6.1.7600.16385)
+
+	# Windows SDK for Windows 7 and .NET Framework 3.5 SP1
+	# Works with VC9
+	# http://www.microsoft.com/en-us/download/details.aspx?id=18950
+	_winsdk_check_microsoft_sdks_registry(v7.0 6.1.7600.16385)
+
+	# Two versions call themselves "v6.1":
+	# Older:
+	# Windows Vista Update & .NET 3.0 SDK
+	# http://www.microsoft.com/en-us/download/details.aspx?id=14477
+
+	# Newer:
+	# Windows Server 2008 & .NET 3.5 SDK
+	# may have broken VS9SP1? they recommend v7.0 instead, or a KB...
+	# http://www.microsoft.com/en-us/download/details.aspx?id=24826
+	_winsdk_check_microsoft_sdks_registry(v6.1 6.1.6000.16384.10)
+
+	# Included in VS 2008
+	_winsdk_check_microsoft_sdks_registry(v6.0A 6.1.6723.1)
+
+	# Microsoft Windows Software Development Kit for Windows Vista and .NET Framework 3.0 Runtime Components
+	# http://blogs.msdn.com/b/stanley/archive/2006/11/08/microsoft-windows-software-development-kit-for-windows-vista-and-net-framework-3-0-runtime-components.aspx
+	_winsdk_check_microsoft_sdks_registry(v6.0 6.0.6000.16384)
+endif()
+
+# Let's not forget the Platform SDKs, which sometimes are useful!
+if(_winsdk_msvc_greater_1200)
+	_winsdk_check_platformsdk_registry("Microsoft Platform SDK for Windows Server 2003 R2" "5.2.3790.2075.51" "D2FF9F89-8AA2-4373-8A31-C838BF4DBBE1")
+	_winsdk_check_platformsdk_registry("Microsoft Platform SDK for Windows Server 2003 SP1" "5.2.3790.1830.15" "8F9E5EF3-A9A5-491B-A889-C58EFFECE8B3")
+endif()
+###
+# Finally, look for "preferred" SDKs
+###
+if(_winsdk_msvc_greater_1310) # Newer than VS .NET/VS Toolkit 2003
+
+
+	# Environment variable for SDK dir
+	if(EXISTS "$ENV{WindowsSDKDir}" AND (NOT "$ENV{WindowsSDKDir}" STREQUAL ""))
+		_winsdk_conditional_append_preferred("WindowsSDKDir environment variable" "$ENV{WindowsSDKDir}")
+	endif()
+
+	if(_winsdk_msvc_less_1600)
+		# Per-user current Windows SDK for VS2005/2008
+		get_filename_component(_sdkdir
+			"[HKEY_CURRENT_USER\\Software\\Microsoft\\Microsoft SDKs\\Windows;CurrentInstallFolder]"
+			ABSOLUTE)
+		_winsdk_conditional_append_preferred("Per-user current Windows SDK" "${_sdkdir}")
+
+		# System-wide current Windows SDK for VS2005/2008
+		get_filename_component(_sdkdir
+			"[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows;CurrentInstallFolder]"
+			ABSOLUTE)
+		_winsdk_conditional_append_preferred("System-wide current Windows SDK" "${_sdkdir}")
+	endif()
+endif()
+
+
+function(windowssdk_name_lookup _dir _outvar)
+	list(FIND _win_sdk_versanddirs "${_dir}" _diridx)
+	math(EXPR _idx "${_diridx} - 1")
+	if(${_idx} GREATER -1)
+		list(GET _win_sdk_versanddirs ${_idx} _ret)
+	else()
+		set(_ret "NOTFOUND")
+	endif()
+	set(${_outvar} "${_ret}" PARENT_SCOPE)
+endfunction()
+
+function(windowssdk_build_lookup _dir _outvar)
+	list(FIND _win_sdk_buildsanddirs "${_dir}" _diridx)
+	math(EXPR _idx "${_diridx} - 1")
+	if(${_idx} GREATER -1)
+		list(GET _win_sdk_buildsanddirs ${_idx} _ret)
+	else()
+		set(_ret "NOTFOUND")
+	endif()
+	set(${_outvar} "${_ret}" PARENT_SCOPE)
+endfunction()
+
+# If we found something...
+if(_win_sdk_dirs)
+	list(GET _win_sdk_dirs 0 WINDOWSSDK_LATEST_DIR)
+	windowssdk_name_lookup("${WINDOWSSDK_LATEST_DIR}"
+		WINDOWSSDK_LATEST_NAME)
+	set(WINDOWSSDK_DIRS ${_win_sdk_dirs})
+
+	# Fallback, in case no preference found.
+	set(WINDOWSSDK_PREFERRED_DIR "${WINDOWSSDK_LATEST_DIR}")
+	set(WINDOWSSDK_PREFERRED_NAME "${WINDOWSSDK_LATEST_NAME}")
+	set(WINDOWSSDK_PREFERRED_FIRST_DIRS ${WINDOWSSDK_DIRS})
+	set(WINDOWSSDK_FOUND_PREFERENCE OFF)
+endif()
+
+# If we found indications of a user preference...
+if(_win_sdk_preferred_sdk_dirs)
+	list(GET _win_sdk_preferred_sdk_dirs 0 WINDOWSSDK_PREFERRED_DIR)
+	windowssdk_name_lookup("${WINDOWSSDK_PREFERRED_DIR}"
+		WINDOWSSDK_PREFERRED_NAME)
+	set(WINDOWSSDK_PREFERRED_FIRST_DIRS
+		${_win_sdk_preferred_sdk_dirs}
+		${_win_sdk_dirs})
+	list(REMOVE_DUPLICATES WINDOWSSDK_PREFERRED_FIRST_DIRS)
+	set(WINDOWSSDK_FOUND_PREFERENCE ON)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(WindowsSDK
+	"No compatible version of the Windows SDK or Platform SDK found."
+	WINDOWSSDK_DIRS)
+
+if(WINDOWSSDK_FOUND)
+	# Internal: Architecture-appropriate library directory names.
+	if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "ARM")
+		if(CMAKE_SIZEOF_VOID_P MATCHES "8")
+			# Only supported in Win10 SDK and up.
+			set(_winsdk_arch8 arm64) # what the WDK for Win8+ calls this architecture
+		else()
+			set(_winsdk_archbare /arm) # what the architecture used to be called in oldest SDKs
+			set(_winsdk_arch arm) # what the architecture used to be called
+			set(_winsdk_arch8 arm) # what the WDK for Win8+ calls this architecture
+		endif()
+	else()
+		if(CMAKE_SIZEOF_VOID_P MATCHES "8")
+			set(_winsdk_archbare /x64) # what the architecture used to be called in oldest SDKs
+			set(_winsdk_arch amd64) # what the architecture used to be called
+			set(_winsdk_arch8 x64) # what the WDK for Win8+ calls this architecture
+		else()
+			set(_winsdk_archbare ) # what the architecture used to be called in oldest SDKs
+			set(_winsdk_arch i386) # what the architecture used to be called
+			set(_winsdk_arch8 x86) # what the WDK for Win8+ calls this architecture
+		endif()
+	endif()
+
+	function(get_windowssdk_from_component _component _var)
+		get_filename_component(_component "${_component}" ABSOLUTE)
+		file(TO_CMAKE_PATH "${_component}" _component)
+		foreach(_sdkdir ${WINDOWSSDK_DIRS})
+			get_filename_component(_sdkdir "${_sdkdir}" ABSOLUTE)
+			string(LENGTH "${_sdkdir}" _sdklen)
+			file(RELATIVE_PATH _rel "${_sdkdir}" "${_component}")
+			# If we don't have any "parent directory" items...
+			if(NOT "${_rel}" MATCHES "[.][.]")
+				set(${_var} "${_sdkdir}" PARENT_SCOPE)
+				return()
+			endif()
+		endforeach()
+		# Fail.
+		set(${_var} "NOTFOUND" PARENT_SCOPE)
+	endfunction()
+	function(get_windowssdk_library_dirs _winsdk_dir _var)
+		set(_result)
+		set(_suffixes
+			"lib${_winsdk_archbare}" # SDKs like 7.1A
+			"lib/${_winsdk_arch}" # just because some SDKs have x86 dir and root dir
+			"lib/w2k/${_winsdk_arch}" # Win2k min requirement
+			"lib/wxp/${_winsdk_arch}" # WinXP min requirement
+			"lib/wnet/${_winsdk_arch}" # Win Server 2003 min requirement
+			"lib/wlh/${_winsdk_arch}"
+			"lib/wlh/um/${_winsdk_arch8}" # Win Vista ("Long Horn") min requirement
+			"lib/win7/${_winsdk_arch}"
+			"lib/win7/um/${_winsdk_arch8}" # Win 7 min requirement
+		)
+		foreach(_ver
+			wlh # Win Vista ("Long Horn") min requirement
+			win7 # Win 7 min requirement
+			win8 # Win 8 min requirement
+			winv6.3 # Win 8.1 min requirement
+		)
+
+			list(APPEND _suffixes
+				"lib/${_ver}/${_winsdk_arch}"
+				"lib/${_ver}/um/${_winsdk_arch8}"
+				"lib/${_ver}/km/${_winsdk_arch8}"
+			)
+		endforeach()
+
+		# Look for WDF libraries in Win10+ SDK
+		foreach(_mode umdf kmdf)
+			file(GLOB _wdfdirs RELATIVE "${_winsdk_dir}" "${_winsdk_dir}/lib/wdf/${_mode}/${_winsdk_arch8}/*")
+			if(_wdfdirs)
+				list(APPEND _suffixes ${_wdfdirs})
+			endif()
+		endforeach()
+
+		# Look in each Win10+ SDK version for the components
+		foreach(_win10ver ${_winsdk_win10vers})
+			foreach(_component um km ucrt mmos)
+				list(APPEND _suffixes "lib/${_win10ver}/${_component}/${_winsdk_arch8}")
+			endforeach()
+		endforeach()
+
+		foreach(_suffix ${_suffixes})
+			# Check to see if a library actually exists here.
+			file(GLOB _libs "${_winsdk_dir}/${_suffix}/*.lib")
+			if(_libs)
+				list(APPEND _result "${_winsdk_dir}/${_suffix}")
+			endif()
+		endforeach()
+		if(NOT _result)
+			set(_result NOTFOUND)
+		else()
+			list(REMOVE_DUPLICATES _result)
+		endif()
+		set(${_var} ${_result} PARENT_SCOPE)
+	endfunction()
+	function(get_windowssdk_include_dirs _winsdk_dir _var)
+		set(_result)
+
+		set(_subdirs shared um winrt km wdf mmos ucrt)
+		set(_suffixes Include)
+
+		foreach(_dir ${_subdirs})
+			list(APPEND _suffixes "Include/${_dir}")
+		endforeach()
+
+		foreach(_ver ${_winsdk_win10vers})
+			foreach(_dir ${_subdirs})
+				list(APPEND _suffixes "Include/${_ver}/${_dir}")
+			endforeach()
+		endforeach()
+
+		foreach(_suffix ${_suffixes})
+			# Check to see if a header file actually exists here.
+			file(GLOB _headers "${_winsdk_dir}/${_suffix}/*.h")
+			if(_headers)
+				list(APPEND _result "${_winsdk_dir}/${_suffix}")
+			endif()
+		endforeach()
+		if(NOT _result)
+			set(_result NOTFOUND)
+		else()
+			list(REMOVE_DUPLICATES _result)
+		endif()
+		set(${_var} ${_result} PARENT_SCOPE)
+	endfunction()
+	function(get_windowssdk_library_dirs_multiple _var)
+		set(_result)
+		foreach(_sdkdir ${ARGN})
+			get_windowssdk_library_dirs("${_sdkdir}" _current_sdk_libdirs)
+			if(_current_sdk_libdirs)
+				list(APPEND _result ${_current_sdk_libdirs})
+			endif()
+		endforeach()
+		if(NOT _result)
+			set(_result NOTFOUND)
+		else()
+			list(REMOVE_DUPLICATES _result)
+		endif()
+		set(${_var} ${_result} PARENT_SCOPE)
+	endfunction()
+	function(get_windowssdk_include_dirs_multiple _var)
+		set(_result)
+		foreach(_sdkdir ${ARGN})
+			get_windowssdk_include_dirs("${_sdkdir}" _current_sdk_incdirs)
+			if(_current_sdk_libdirs)
+				list(APPEND _result ${_current_sdk_incdirs})
+			endif()
+		endforeach()
+		if(NOT _result)
+			set(_result NOTFOUND)
+		else()
+			list(REMOVE_DUPLICATES _result)
+		endif()
+		set(${_var} ${_result} PARENT_SCOPE)
+	endfunction()
+endif()

--- a/CMake/MinGWSearchPathExtras.cmake
+++ b/CMake/MinGWSearchPathExtras.cmake
@@ -1,0 +1,83 @@
+# - Additional help finding search paths on MinGW distributions, including MSYS2.
+#
+# Much of this is really more in the purview of CMake or the packages of CMake for
+# those distributions, but if I can centralize/simplify the pain here, it's worth doing.
+#
+# Variables: (all are internal cache variables)
+#  MINGWSEARCH_INCLUDE_DIRS - use under PATHS in your find_path() commands
+#  MINGWSEARCH_LIBRARY_DIRS - use under PATHS in your find_library() commands
+#  MINGWSEARCH_TARGET_TRIPLE - something like x86_64-w64-mingw32 or i686-w64-mingw32, use as you see fit.
+#
+# Original Author:
+# 2016 Ryan Pavlik <ryan@sensics.com> <ryan.pavlik@gmail.com>
+#
+# Copyright Sensics, Inc. 2016.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+if(MINGW AND NOT MINGWSEARCH_COMPLETED)
+    ###
+    # Helper function
+    ###
+    function(_mingwsearch_conditional_add _var _path)
+        #message(STATUS "conditional add to ${_var}: ${_path}")
+        if(("${_path}" MATCHES "registry") OR (NOT IS_DIRECTORY "${_path}"))
+            # Path invalid - do not add
+            return()
+        endif()
+        list(FIND ${_var} "${_path}" _idx)
+        if(_idx GREATER -1)
+            # Path already in list - do not add
+            return()
+        endif()
+        # Not yet in the list, so we'll add it
+        list(APPEND ${_var} "${_path}")
+        set(${_var} ${${_var}} PARENT_SCOPE)
+    endfunction()
+
+    # Clear the working variables.
+    set(MINGWSEARCH_INCLUDE_DIRS_WORK)
+    set(MINGWSEARCH_LIBRARY_DIRS_WORK)
+    set(_mingw_target_triple)
+
+    # Try to find the string like x86_64-w64-mingw32 by parsing the implicit link directories...
+    # TODO this is a hack that either should be resolved in CMake or in MSYS2's package of CMake.
+    foreach(_link_dir ${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES})
+        _mingwsearch_conditional_add(MINGWSEARCH_LIBRARY_DIRS_WORK "${_link_dir}")
+        if("${_link_dir}" MATCHES "/([^/]*-mingw32)/lib")
+            set(_mingw_target_triple ${CMAKE_MATCH_1})
+            get_filename_component(_mingw_internal_basedir "${_link_dir}" PATH)
+            # Try adding the parallel include dir
+            _mingwsearch_conditional_add(MINGWSEARCH_INCLUDE_DIRS_WORK "${_mingw_internal_basedir}/include")
+            if(NOT CMAKE_CROSSCOMPILING)
+                # Try going up a level, since the directory with the target is usually a sibling to the main prefix.
+                get_filename_component(_mingw_main_basedir_candidate "${_mingw_internal_basedir}/.." ABSOLUTE)
+                if(NOT ("${_mingw_main_basedir_candidate}" STREQUAL "${_mingw_internal_basedir}"))
+                    # If we could go up a level, add that include dir too.
+                    _mingwsearch_conditional_add(MINGWSEARCH_INCLUDE_DIRS_WORK "${_mingw_main_basedir_candidate}/include")
+                endif()
+            endif()
+        endif()
+    endforeach()
+
+    ###
+    # Output results.
+    ###
+    if(MINGWSEARCH_INCLUDE_DIRS_WORK)
+        set(MINGWSEARCH_INCLUDE_DIRS "${MINGWSEARCH_INCLUDE_DIRS_WORK}" CACHE INTERNAL "" FORCE)
+        #message(STATUS "MINGWSEARCH_INCLUDE_DIRS ${MINGWSEARCH_INCLUDE_DIRS}")
+    endif()
+
+    if(MINGWSEARCH_LIBRARY_DIRS_WORK)
+        set(MINGWSEARCH_LIBRARY_DIRS "${MINGWSEARCH_LIBRARY_DIRS_WORK}" CACHE INTERNAL "" FORCE)
+        #message(STATUS "MINGWSEARCH_LIBRARY_DIRS ${MINGWSEARCH_LIBRARY_DIRS}")
+    endif()
+
+    if(_mingw_target_triple)
+        set(MINGWSEARCH_TARGET_TRIPLE ${_mingw_target_triple} CACHE INTERNAL "" FORCE)
+        #message(STATUS "MINGWSEARCH_TARGET_TRIPLE ${MINGWSEARCH_TARGET_TRIPLE}")
+    endif()
+
+    set(MINGWSEARCH_COMPLETED TRUE CACHE INTERNAL "" FORCE)
+endif()

--- a/CMake/PrefixListGlob.cmake
+++ b/CMake/PrefixListGlob.cmake
@@ -1,0 +1,36 @@
+# - For each given prefix in a list, glob using the prefix+pattern
+#
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+if(__prefix_list_glob)
+	return()
+endif()
+set(__prefix_list_glob YES)
+
+function(prefix_list_glob var pattern)
+	set(_out)
+	set(_result)
+	foreach(prefix ${ARGN})
+		file(GLOB _globbed ${prefix}${pattern})
+		if(_globbed)
+			list(SORT _globbed)
+			list(REVERSE _globbed)
+			list(APPEND _out ${_globbed})
+		endif()
+	endforeach()
+	foreach(_name ${_out})
+		get_filename_component(_name "${_name}" ABSOLUTE)
+		list(APPEND _result "${_name}")
+	endforeach()
+
+	set(${var} "${_result}" PARENT_SCOPE)
+endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,14 @@ else()
     if (WIN32)
         # WINDOWS BUILD CONFIGURATION
 
-        find_package(WinDDK REQUIRED)
+        find_package(WinHID REQUIRED)
+        if(MSVC AND (NOT MSVC_VERSION LESS 1600) AND (WINHID_INCLUDE_DIR MATCHES "api"))
+            # Move up a directory so the #include <api/hidsdi.h> works
+            # New versions of VC, with old SDKs, get weird if you directly add the path with
+            # hidsdi.h to the include path.
+            get_filename_component(WINHID_INCLUDE_DIRS "${WINHID_INCLUDE_DIR}/.." ABSOLUTE)
+            add_definitions(-DFREESPACE_NEED_DDK_WORKAROUND)
+        endif()
 
         # If using Visual Studio 9 (2008) then we need a couple special includes to make things work
         IF(MSVC90)
@@ -138,7 +145,7 @@ else()
             include_directories(${WINDDK_INCLUDE_DIR}/api)
         ENDIF()
 
-        include_directories(${WINDDK_INCLUDE_DIR})
+        include_directories(${WINHID_INCLUDE_DIRS})
 
         add_definitions(-DUNICODE -D_UNICODE)
 
@@ -152,31 +159,7 @@ else()
 
         set_target_properties(freespace PROPERTIES PREFIX "lib")
 
-
-	    IF (CMAKE_SIZEOF_VOID_P EQUAL 8)   # Means we are using 64-bit
-	        set(_hid ${WINDDK_WIN7_X64_HID_LIB})
-            set(_setupapi ${WINDDK_WIN7_X64_SETUPAPI_LIB})
-	    ELSE()
-	        IF (${CMAKE_SYSTEM_VERSION} EQUAL 5.1)  # Means we are running XP
-	            set(_hid ${WINDDK_WINXP_X86_HID_LIB})
-                set(_setupapi ${WINDDK_WINXP_X86SETUPAPID_LIB})
-	        ELSE()
-	            set(_hid ${WINDDK_WIN7_X86_HID_LIB})
-                set(_setupapi ${WINDDK_WIN7_X86_SETUPAPI_LIB})
-	        ENDIF()
-	    ENDIF()
-        
-        if (NOT _hid)
-            message(FATAL_ERROR "Could not locate hid.lib")
-        endif()
-        
-        if (NOT _setupapi)
-            # Not found in WinDDK, assume it's in default search path
-            set(_setupapi "setupapi.lib")
-        endif()
-
-        target_link_libraries(freespace ${_hid})
-        target_link_libraries(freespace ${_setupapi})
+        target_link_libraries(freespace ${WINHID_LIBRARIES})
 
     elseif(UNIX)
         # Additional headers

--- a/include/freespace/freespace_deviceTable.h
+++ b/include/freespace/freespace_deviceTable.h
@@ -23,11 +23,12 @@
 #include <stdint.h>
 #include <windows.h>
 
-#if _MSC_VER >= 1600
-// With VC2010 and the WinDDK 7600, setting the include path to be have the
+#ifdef FREESPACE_NEED_DDK_WORKAROUND
+// With VC2010+ and the WinDDK 7600, setting the include path to have the
 // WinDDK inc/api directory causes build failure.
 // The workaround is to only have the /inc directory in the path, and add
 // the api prefix to hidsdi.h.
+// This is not required for more recent DDK/WDK/Windows SDK releases.
 #include <api/hidsdi.h>
 #else
 #include <hidsdi.h>

--- a/win32/freespace_win32.h
+++ b/win32/freespace_win32.h
@@ -75,11 +75,12 @@ extern "C" {
 #include <setupapi.h>
 #include <dbt.h>
 
-#if _MSC_VER >= 1600
-// With VC2010 and the WinDDK 7600, setting the include path to be have the 
-// WinDDK inc/api directory causes build failure.  
-// The workaround is to only have the /inc directory in the path, and add 
-// the api prefix to hidsdi.h.  
+#ifdef FREESPACE_NEED_DDK_WORKAROUND
+// With VC2010+ and the WinDDK 7600, setting the include path to have the
+// WinDDK inc/api directory causes build failure.
+// The workaround is to only have the /inc directory in the path, and add
+// the api prefix to hidsdi.h.
+// This is not required for more recent DDK/WDK/Windows SDK releases.
 #include <api/hidsdi.h>
 #else
 #include <hidsdi.h>


### PR DESCRIPTION
(This is build stuff I originally worked on for the OSVR FSM-9 driver, just updated a bit)

Add alternate CMake modules for finding the HID headers/libraries.

Since we can now build with newer than DDK 7600, there is a define that
has taken place of the pure MSVC version check in two headers. Build with
newer Windows SDKs and compilers, and its status as off by default will be
right.

(This also fixes the build of libfreespace with msys2/mingw-w64)

A demonstration: on a fairly fresh machine, with Visual Studio 2013 and 2015 community installed on it (Pretty sure I haven't installed any Windows Driver Kit yet, since I don't have a directory in redist for difx/dpinst, and I don't have the full Windows 10 SDK on it yet), I can configure and build libfreespace for VS2015, and I did no manual configuration, environment variables, or anything special here:
![screenshot 317](https://cloud.githubusercontent.com/assets/61129/14797311/bdb6d350-0af7-11e6-93d6-90b8ad04f852.png)
