### PR TITLE
Add utility for mouse/pointer and buttons

### DIFF
--- a/common/freespace_util.c
+++ b/common/freespace_util.c
@@ -493,3 +493,36 @@ LIBFREESPACE_API int freespace_util_getActClass(struct freespace_MotionEngineOut
     return 0;
 }
 
+/******************************************************************************
+ * freespace_util_getMouseAndButtons
+ */
+LIBFREESPACE_API int freespace_util_getMouseAndButtons(struct freespace_MotionEngineOutput const * meOutPkt,
+                                                       struct MultiAxisSensor * sensor) {
+
+    switch (meOutPkt->formatSelect) {
+    case 0:
+        if (meOutPkt->ff0 == 0) {
+            return -1; // Mouse flag not set
+        }
+        break;
+    case 1:
+    case 2:
+        return -2; // No mouse data in this format
+    case 3:
+        if (meOutPkt->ff0 == 0) {
+            return -1; // Mouse flag not set
+        }
+        break;
+    default:
+        return -3; // The format number was unrecognized
+    }
+
+    // Extract and convert the mouse data
+    sensor->x = meOutPkt->meData[1]; // Delta X
+    sensor->y = meOutPkt->meData[3]; // Delta Y
+    sensor->z = meOutPkt->meData[5]; // Delta Wheel
+    sensor->w = meOutPkt->meData[0]; // Button bits
+
+    return 0;
+}
+

--- a/include/freespace/freespace_util.h
+++ b/include/freespace/freespace_util.h
@@ -199,7 +199,7 @@ LIBFREESPACE_API int freespace_util_getActClass(struct freespace_MotionEngineOut
  *
  * Get the mouse and button values from a MEOut packet.
  *
- * For MEOut Format 0 and 3, X and Y units are mickeys, Z in detents and W in bitmask (0 – not pressed, 1 – pressed).
+ * For MEOut Format 0 and 3, X and Y units are mickeys, Z is detents and W is bitmask (0 - not pressed, 1 - pressed).
  *
  * @param meOutPkt A pointer to the MEOut packet to extract the mouse and buttons from.
  * @param sensor A pointer to where to store the extracted 8-bit values. Uses X - Delta X, Y - Delta Y, Z - Delta Wheel, W - Button bits.

--- a/include/freespace/freespace_util.h
+++ b/include/freespace/freespace_util.h
@@ -195,6 +195,22 @@ LIBFREESPACE_API int freespace_util_getAngPos(struct freespace_MotionEngineOutpu
 LIBFREESPACE_API int freespace_util_getActClass(struct freespace_MotionEngineOutput const * meOutPkt,
                                                 struct MultiAxisSensor * sensor);
 
+/** @ingroup util
+ *
+ * Get the mouse and button values from a MEOut packet.
+ *
+ * For MEOut Format 0 and 3, X and Y units are mickeys, Z in detents and W in bitmask (0 – not pressed, 1 – pressed).
+ *
+ * @param meOutPkt A pointer to the MEOut packet to extract the mouse and buttons from.
+ * @param sensor A pointer to where to store the extracted 8-bit values. Uses X - Delta X, Y - Delta Y, Z - Delta Wheel, W - Button bits.
+ * @return 0 if successful
+ *         -1 if the format flag was not set for the mouse and buttons field
+ *         -2 if the meOutPkt does not contain mouse or buttons at all
+ *         -3 if the format select number is unrecognized
+ */
+LIBFREESPACE_API int freespace_util_getMouseAndButtons(struct freespace_MotionEngineOutput const * meOutPkt,
+                                                       struct MultiAxisSensor * sensor);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The PR will add a new utility function called `freespace_util_getMouseAndButtons`, which simplifies retrieving mouse pointer and button values from a complex motion engine output packet (similar to existing utility functions such as `freespace_util_getAcceleration`).